### PR TITLE
Enable navigation between generated pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,17 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Container, Theme } from './settings/types';
 import { GoudGebouwdFeedPage } from './components/generated/GoudGebouwdFeedPage';
+import { GoudGebouwdMapPage } from './components/generated/GoudGebouwdMapPage';
+import { GoudGebouwdIndexPage } from './components/generated/GoudGebouwdIndexPage';
+import { GoudGebouwdAboutPage } from './components/generated/GoudGebouwdAboutPage';
 
 let theme: Theme = 'light';
 // only use 'centered' container for standalone components, never for full page apps or websites.
 let container: Container = 'none';
 
 function App() {
+  const [currentPage, setCurrentPage] = useState<'feed' | 'map' | 'index' | 'about'>('feed');
+
   function setTheme(theme: Theme) {
     if (theme === 'dark') {
       document.documentElement.classList.add('dark');
@@ -17,10 +22,24 @@ function App() {
 
   setTheme(theme);
 
+  const handleNavigate = useCallback((page: 'feed' | 'map' | 'index' | 'about') => {
+    setCurrentPage(page);
+  }, []);
+
   const generatedComponent = useMemo(() => {
     // THIS IS WHERE THE TOP LEVEL GENRATED COMPONENT WILL BE RETURNED!
-    return <GoudGebouwdFeedPage />;
-  }, []);
+    switch (currentPage) {
+      case 'map':
+        return <GoudGebouwdMapPage onNavigate={handleNavigate} />;
+      case 'index':
+        return <GoudGebouwdIndexPage onNavigate={handleNavigate} />;
+      case 'about':
+        return <GoudGebouwdAboutPage onNavigate={handleNavigate} />;
+      case 'feed':
+      default:
+        return <GoudGebouwdFeedPage onNavigate={handleNavigate} />;
+    }
+  }, [currentPage, handleNavigate]);
 
   if (container === 'centered') {
     return (


### PR DESCRIPTION
## Summary
- add client-side page state to switch between feed, map, index, and about views
- pass navigation handler down so menu buttons switch to the selected page

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_b_68e67c0f27ac8332a01efee370d53b75