### PR TITLE
Match header layout to provided mockup

### DIFF
--- a/src/components/generated/Navigation.tsx
+++ b/src/components/generated/Navigation.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import { motion } from "framer-motion";
 
 export interface NavigationProps {
   currentPage: 'feed' | 'map' | 'index' | 'about';
@@ -11,89 +10,75 @@ export interface NavigationProps {
 
 type Page = NavigationProps['currentPage'];
 
+const pageToHash: Record<Page, string> = {
+  feed: '#feed',
+  map: '#map',
+  index: '#index',
+  about: '#about'
+};
+
+const pageToLabel: Record<Page, string> = {
+  feed: 'Feed',
+  map: 'Kaart',
+  index: 'Index',
+  about: 'Over'
+};
+
 export default function Navigation({
   currentPage,
   onNavigate,
   className = ''
 }: NavigationProps) {
-  const navigateTo = (page: Page) => {
-    onNavigate?.(page);
+  const handleLinkClick = (event: React.MouseEvent<HTMLAnchorElement>, page: Page) => {
+    if (!onNavigate) {
+      return;
+    }
+
+    event.preventDefault();
+    onNavigate(page);
 
     if (typeof window !== 'undefined') {
-      const newHash = `#${page}`;
-      if (window.location.hash !== newHash) {
-        window.history.replaceState(null, '', newHash);
+      const targetHash = pageToHash[page];
+      if (window.location.hash !== targetHash) {
+        window.history.replaceState(null, '', targetHash);
       }
     }
   };
 
   return (
-    <motion.nav
-      className={`fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-md border-b border-[#e8e6dc] ${className}`}
-      initial={{ opacity: 0, y: -20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
-    >
-      <div className="max-w-[1800px] mx-auto px-6 sm:px-8 lg:px-12 py-5 sm:py-6">
-        <div className="flex justify-between items-center">
-          <div className="flex gap-6 sm:gap-8 lg:gap-12">
-            <button
-              onClick={() => navigateTo('feed')}
-              className={`text-sm sm:text-base font-medium transition-all duration-300 relative group ${currentPage === 'feed' ? 'text-[#4a7c59]' : 'text-[#6b6b6b] hover:text-[#333]'}`}
-            >
-              <span>Feed</span>
-              {currentPage === 'feed' && (
-                <motion.div
-                  className="absolute -bottom-1.5 left-0 right-0 h-0.5 bg-[#4a7c59]"
-                  layoutId="activeNav"
-                  transition={{ type: "spring", stiffness: 380, damping: 30 }}
-                />
-              )}
-            </button>
-            <button
-              onClick={() => navigateTo('map')}
-              className={`text-sm sm:text-base font-medium transition-all duration-300 relative group ${currentPage === 'map' ? 'text-[#4a7c59]' : 'text-[#6b6b6b] hover:text-[#333]'}`}
-            >
-              <span>Kaart</span>
-              {currentPage === 'map' && (
-                <motion.div
-                  className="absolute -bottom-1.5 left-0 right-0 h-0.5 bg-[#4a7c59]"
-                  layoutId="activeNav"
-                  transition={{ type: "spring", stiffness: 380, damping: 30 }}
-                />
-              )}
-            </button>
-            <button
-              onClick={() => navigateTo('index')}
-              className={`text-sm sm:text-base font-medium transition-all duration-300 relative group ${currentPage === 'index' ? 'text-[#4a7c59]' : 'text-[#6b6b6b] hover:text-[#333]'}`}
-            >
-              <span>Index</span>
-              {currentPage === 'index' && (
-                <motion.div
-                  className="absolute -bottom-1.5 left-0 right-0 h-0.5 bg-[#4a7c59]"
-                  layoutId="activeNav"
-                  transition={{ type: "spring", stiffness: 380, damping: 30 }}
-                />
-              )}
-            </button>
-          </div>
-          <div>
-            <button
-              onClick={() => navigateTo('about')}
-              className={`text-sm sm:text-base font-medium transition-all duration-300 relative group ${currentPage === 'about' ? 'text-[#4a7c59]' : 'text-[#6b6b6b] hover:text-[#333]'}`}
-            >
-              <span>Over</span>
-              {currentPage === 'about' && (
-                <motion.div
-                  className="absolute -bottom-1.5 left-0 right-0 h-0.5 bg-[#4a7c59]"
-                  layoutId="activeNav"
-                  transition={{ type: "spring", stiffness: 380, damping: 30 }}
-                />
-              )}
-            </button>
-          </div>
-        </div>
+    <header id="header" className={`o-app__header ${className}`.trim()}>
+      <div className="m-header">
+        <nav className="m-header__nav" aria-label="Hoofdmenu">
+          <ul className="m-header__list">
+            {(['feed', 'map', 'index'] as Page[]).map(page => (
+              <li key={page} className="m-header__item">
+                <a
+                  href={pageToHash[page]}
+                  className="m-header__link"
+                  aria-current={currentPage === page ? 'page' : undefined}
+                  onClick={event => handleLinkClick(event, page)}
+                >
+                  {pageToLabel[page]}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <nav className="m-header__actions" aria-label="actiemenu">
+          <ul className="m-header__list">
+            <li className="m-header__item">
+              <a
+                href={pageToHash.about}
+                className="m-header__link"
+                aria-current={currentPage === 'about' ? 'page' : undefined}
+                onClick={event => handleLinkClick(event, 'about')}
+              >
+                {pageToLabel.about}
+              </a>
+            </li>
+          </ul>
+        </nav>
       </div>
-    </motion.nav>
+    </header>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -143,3 +143,90 @@ body {
     overscroll-behavior-x: none;
   }
 }
+
+.o-app__header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid #e8e6dc;
+  width: 100%;
+}
+
+.m-header {
+  margin: 0 auto;
+  max-width: 1800px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+}
+
+@media (min-width: 640px) {
+  .m-header {
+    padding: 1.5rem 2rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .m-header {
+    padding: 1.75rem 3rem;
+  }
+}
+
+.m-header__nav,
+.m-header__actions {
+  display: flex;
+}
+
+.m-header__list {
+  display: flex;
+  gap: 2rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.m-header__item {
+  display: flex;
+}
+
+.m-header__link {
+  position: relative;
+  display: inline-flex;
+  font-size: 0.9375rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6f6c5f;
+  text-decoration: none;
+  padding-bottom: 0.25rem;
+  transition: color 150ms ease-in-out;
+}
+
+.m-header__link:hover,
+.m-header__link:focus {
+  color: #383530;
+}
+
+.m-header__link[aria-current='page'] {
+  color: #1f1e1b;
+}
+
+.m-header__link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 1px;
+  background-color: transparent;
+  transition: background-color 150ms ease-in-out;
+}
+
+.m-header__link:hover::after,
+.m-header__link:focus::after,
+.m-header__link[aria-current='page']::after {
+  background-color: #1f1e1b;
+}


### PR DESCRIPTION
## Summary
- replace the generated navigation component with semantic markup matching the provided header structure
- add global styles to reproduce the mockup layout, spacing, and interaction cues

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_b_68e75820c9148332b425eabdba2acb16