### PR TITLE
Update navigation menu styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,9 @@ import { GoudGebouwdMapPage } from './components/generated/GoudGebouwdMapPage';
 import { GoudGebouwdIndexPage } from './components/generated/GoudGebouwdIndexPage';
 import { GoudGebouwdAboutPage } from './components/generated/GoudGebouwdAboutPage';
 
-let theme: Theme = 'light';
+const theme: Theme = 'light';
 // only use 'centered' container for standalone components, never for full page apps or websites.
-let container: Container = 'none';
+const container: Container = 'none';
 
 type Page = 'feed' | 'map' | 'index' | 'about';
 

--- a/src/components/generated/App.tsx
+++ b/src/components/generated/App.tsx
@@ -4,9 +4,9 @@ import { GoudGebouwdFeedPage } from './GoudGebouwdFeedPage';
 import { GoudGebouwdMapPage } from './GoudGebouwdMapPage';
 import { GoudGebouwdIndexPage } from './GoudGebouwdIndexPage';
 import { GoudGebouwdAboutPage } from './GoudGebouwdAboutPage';
-let theme: Theme = 'light';
+const theme: Theme = 'light';
 // only use 'centered' container for standalone components, never for full page apps or websites.
-let container: Container = 'none';
+const container: Container = 'none';
 type Page = 'feed' | 'map' | 'index' | 'about';
 
 const resolvePageFromHash = (hash: string): Page => {

--- a/src/components/generated/Navigation.tsx
+++ b/src/components/generated/Navigation.tsx
@@ -24,6 +24,9 @@ const pageToLabel: Record<Page, string> = {
   about: 'Over'
 };
 
+const LEFT_LINKS: Page[] = ['feed', 'map', 'index'];
+const RIGHT_LINKS: Page[] = ['about'];
+
 export default function Navigation({
   currentPage,
   onNavigate,
@@ -45,26 +48,26 @@ export default function Navigation({
     }
   };
 
+  const renderLink = (page: Page) => (
+    <a
+      key={page}
+      href={pageToHash[page]}
+      className="menu-link"
+      aria-current={currentPage === page ? 'page' : undefined}
+      onClick={event => handleLinkClick(event, page)}
+    >
+      {pageToLabel[page]}
+    </a>
+  );
+
   return (
-    <header id="header" className={`o-app__header ${className}`.trim()}>
-      <div className="m-header">
-        <nav className="m-header__nav" aria-label="Hoofdmenu">
-          <ul className="m-header__list">
-            {(['feed', 'map', 'index', 'about'] as Page[]).map(page => (
-              <li key={page} className="m-header__item">
-                <a
-                  href={pageToHash[page]}
-                  className="m-header__link"
-                  aria-current={currentPage === page ? 'page' : undefined}
-                  onClick={event => handleLinkClick(event, page)}
-                >
-                  {pageToLabel[page]}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
+    <section className={`menu ${className}`.trim()}>
+      <nav className="menu-left" aria-label="Hoofdmenu">
+        {LEFT_LINKS.map(renderLink)}
+      </nav>
+      <div className="menu-right">
+        {RIGHT_LINKS.map(renderLink)}
       </div>
-    </header>
+    </section>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -144,89 +144,40 @@ body {
   }
 }
 
-.o-app__header {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(8px);
-  border-bottom: 1px solid #e8e6dc;
-  width: 100%;
-}
-
-.m-header {
-  margin: 0 auto;
-  max-width: 1800px;
-  padding: 1.25rem 1.5rem;
+.menu {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 2rem;
+  background: #f2f4ef;
+  padding: 12px 24px;
+  border-radius: 8px;
+  position: fixed;
+  top: 24px;
+  left: 24px;
+  right: 24px;
+  z-index: 50;
 }
 
-@media (min-width: 640px) {
-  .m-header {
-    padding: 1.5rem 2rem;
-  }
-}
-
-@media (min-width: 1024px) {
-  .m-header {
-    padding: 1.75rem 3rem;
-  }
-}
-
-.m-header__nav,
-.m-header__actions {
+.menu-left,
+.menu-right {
   display: flex;
+  gap: 16px;
 }
 
-.m-header__list {
-  display: flex;
-  gap: 2rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.m-header__item {
-  display: flex;
-}
-
-.m-header__link {
-  position: relative;
-  display: inline-flex;
-  font-size: 0.9375rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: #6f6c5f;
+.menu-link {
+  font-family: monospace;
   text-decoration: none;
-  padding-bottom: 0.25rem;
-  transition: color 150ms ease-in-out;
+  color: #222;
+  font-size: 16px;
+  transition: color 0.2s ease;
 }
 
-.m-header__link:hover,
-.m-header__link:focus {
-  color: #383530;
+.menu-link:hover,
+.menu-link:focus {
+  color: #007b4d;
 }
 
-.m-header__link[aria-current='page'] {
-  color: #1f1e1b;
-}
-
-.m-header__link::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 1px;
-  background-color: transparent;
-  transition: background-color 150ms ease-in-out;
-}
-
-.m-header__link:hover::after,
-.m-header__link:focus::after,
-.m-header__link[aria-current='page']::after {
-  background-color: #1f1e1b;
+.menu-link[aria-current='page'] {
+  color: #007b4d;
+  font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- restyle the navigation component with the new fixed menu layout and link grouping
- add supporting global styles for the menu while keeping current-page highlighting
- switch theme and container settings to const to satisfy lint rules

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_b_68ea8caf66408325bed5a8ff00221d4c