### PR TITLE
Refine navigation layout styling

### DIFF
--- a/src/components/generated/Navigation.tsx
+++ b/src/components/generated/Navigation.tsx
@@ -24,8 +24,7 @@ const pageToLabel: Record<Page, string> = {
   about: 'Over'
 };
 
-const LEFT_LINKS: Page[] = ['feed', 'map', 'index'];
-const RIGHT_LINKS: Page[] = ['about'];
+const LINKS: Page[] = ['feed', 'map', 'index', 'about'];
 
 export default function Navigation({
   currentPage,
@@ -52,7 +51,7 @@ export default function Navigation({
     <a
       key={page}
       href={pageToHash[page]}
-      className="menu-link"
+      className="main-nav__link"
       aria-current={currentPage === page ? 'page' : undefined}
       onClick={event => handleLinkClick(event, page)}
     >
@@ -61,13 +60,8 @@ export default function Navigation({
   );
 
   return (
-    <section className={`menu ${className}`.trim()}>
-      <nav className="menu-left" aria-label="Hoofdmenu">
-        {LEFT_LINKS.map(renderLink)}
-      </nav>
-      <div className="menu-right">
-        {RIGHT_LINKS.map(renderLink)}
-      </div>
-    </section>
+    <nav className={`main-nav ${className}`.trim()} aria-label="Hoofdmenu">
+      {LINKS.map(renderLink)}
+    </nav>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -144,40 +144,35 @@ body {
   }
 }
 
-.menu {
+.main-nav {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: row;
+  gap: 16px;
   background: #f2f4ef;
   padding: 12px 24px;
   border-radius: 8px;
+  width: fit-content;
+  align-items: center;
   position: fixed;
   top: 24px;
   left: 24px;
-  right: 24px;
-  z-index: 50;
+  z-index: 10;
 }
 
-.menu-left,
-.menu-right {
-  display: flex;
-  gap: 16px;
-}
-
-.menu-link {
-  font-family: monospace;
+.main-nav__link {
   text-decoration: none;
   color: #222;
+  font-family: monospace;
   font-size: 16px;
-  transition: color 0.2s ease;
+  transition: color 0.2s;
 }
 
-.menu-link:hover,
-.menu-link:focus {
+.main-nav__link:hover,
+.main-nav__link:focus {
   color: #007b4d;
 }
 
-.menu-link[aria-current='page'] {
+.main-nav__link[aria-current='page'] {
   color: #007b4d;
   font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- collapse the navigation component into a single `<nav>` that renders every page link consistently
- refresh the associated styles to match the compact fixed navigation design from the provided snippet

## Testing
- yarn lint *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68ea8e65fe588325b15a1015527c79b8