### PR TITLE
Update feed page project name to Garrelsweer

### DIFF
--- a/src/components/generated/GoudGebouwdFeedPage.tsx
+++ b/src/components/generated/GoudGebouwdFeedPage.tsx
@@ -28,7 +28,7 @@ const projects: Project[] = [{
 }, {
   id: '2',
   number: '#07',
-  title: 'Wilgenbos',
+  title: 'Garrelsweer',
   image: 'https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=800&q=80',
   type: 'image'
 }, {


### PR DESCRIPTION
## Summary
- rename the Wilgenbos project card to Garrelsweer on the feed page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68eb5d3d54b48325bc21b28467248cc7