### PR TITLE
Update feed entry title to Garreslweer

### DIFF
--- a/src/components/generated/GoudGebouwdIndexPage.tsx
+++ b/src/components/generated/GoudGebouwdIndexPage.tsx
@@ -68,7 +68,7 @@ const projects: Project[] = [{
 }, {
   id: '7',
   number: '#07',
-  title: 'Wilgenbos woonwijk',
+  title: 'Garreslweer woonwijk',
   location: 'Garrelsweer',
   architect: 'ONIX',
   year: '2021',


### PR DESCRIPTION
## Summary
- update the feed entry title so the previous "Wilgenbos" label now reads "Garreslweer"

## Testing
- not run (yarn install returned HTTP 403 while fetching packages)

------
https://chatgpt.com/codex/tasks/task_b_68ed0fe34c40832587ffe71071588a9b