### PR TITLE
Make about page email address clickable

### DIFF
--- a/src/components/generated/GoudGebouwdAboutPage.tsx
+++ b/src/components/generated/GoudGebouwdAboutPage.tsx
@@ -186,7 +186,12 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
                 </h3>
                 <div className="text-[#6b6b6b] space-y-2">
                   <p>
-                    <span>info@foutgebouwd.nl</span>
+                    <a
+                      href="mailto:info@foutgebouwd.nl"
+                      className="hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a7c59]"
+                    >
+                      info@foutgebouwd.nl
+                    </a>
                   </p>
                   <p>
                     <span>www.foutgebouwd.nl</span>


### PR DESCRIPTION
## Summary
- update the About page contact section to wrap the info@foutgebouwd.nl address in a mailto link with accessible focus styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ed15c3e598832592336d6dfb43365d