### PR TITLE
Revert rename of CominSoon component

### DIFF
--- a/src/CominSoon.tsx
+++ b/src/CominSoon.tsx
@@ -263,3 +263,5 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
     </div>
   );
 };
+
+export default GoudGebouwdAboutPage;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,7 +20,10 @@ document.addEventListener('DOMContentLoaded', forceLightMode);
 const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 mediaQuery.addEventListener('change', forceLightMode);
 import { createRoot } from 'react-dom/client';
-import App from './App.tsx';
-createRoot(document.getElementById('root')!).render(<StrictMode>
-    <App />
-  </StrictMode>);
+import CominSoon from './CominSoon.tsx';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <CominSoon />
+  </StrictMode>
+);


### PR DESCRIPTION
## Summary
- restore the original `CominSoon.tsx` file name
- update the app entry point to render the `CominSoon` component and export it as default

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f534075cd88325aaccddbed205e789