### PR TITLE
Update website inspiration link to open in new tab

### DIFF
--- a/src/CominSoon.tsx
+++ b/src/CominSoon.tsx
@@ -252,8 +252,17 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
                     </a>
                   </div>
                   <div className="rounded-xl border border-[#e6e6e6] bg-white/90 p-5 shadow-sm">
-                    <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-[#7a7a7a]">Website</h3>
-                    <p className="mt-2 text-lg font-semibold text-[#4a7c59]">www.foutgebouwd.nl</p>
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-[#7a7a7a]">
+                      Geïnspireerd door
+                    </h3>
+                    <a
+                      href="https://www.goudbebouwd.nl"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-flex items-center text-lg font-semibold text-[#4a7c59] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a7c59]"
+                    >
+                      www.goudbebouwd.nl
+                    </a>
                   </div>
                 </div>
               </div>

--- a/src/components/generated/GoudGebouwdAboutPage.tsx
+++ b/src/components/generated/GoudGebouwdAboutPage.tsx
@@ -252,8 +252,17 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
                     </a>
                   </div>
                   <div className="rounded-xl border border-[#e6e6e6] bg-white/90 p-5 shadow-sm">
-                    <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-[#7a7a7a]">Website</h3>
-                    <p className="mt-2 text-lg font-semibold text-[#4a7c59]">www.foutgebouwd.nl</p>
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-[#7a7a7a]">
+                      Geïnspireerd door
+                    </h3>
+                    <a
+                      href="https://www.goudbebouwd.nl"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-flex items-center text-lg font-semibold text-[#4a7c59] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a7c59]"
+                    >
+                      www.goudbebouwd.nl
+                    </a>
                   </div>
                 </div>
               </div>

--- a/src/components/generated/coming soon
+++ b/src/components/generated/coming soon
@@ -252,8 +252,17 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
                     </a>
                   </div>
                   <div className="rounded-xl border border-[#e6e6e6] bg-white/90 p-5 shadow-sm">
-                    <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-[#7a7a7a]">Website</h3>
-                    <p className="mt-2 text-lg font-semibold text-[#4a7c59]">www.foutgebouwd.nl</p>
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-[#7a7a7a]">
+                      Geïnspireerd door
+                    </h3>
+                    <a
+                      href="https://www.goudbebouwd.nl"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-flex items-center text-lg font-semibold text-[#4a7c59] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a7c59]"
+                    >
+                      www.goudbebouwd.nl
+                    </a>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- replace the static website text with an external link to goudbebouwd.nl
- ensure the link opens in a new tab with appropriate focus and hover styling across generated variants

## Testing
- yarn lint *(fails: Duplicate export 'default' in tailwind.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_68f53a276224832594afa4adb477cfdb