### PR TITLE
Fix Goud Gebouwd external link domain

### DIFF
--- a/src/CominSoon.tsx
+++ b/src/CominSoon.tsx
@@ -256,12 +256,12 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
                       Geïnspireerd door
                     </h3>
                     <a
-                      href="https://www.goudbebouwd.nl"
+                      href="https://www.goudgebouwd.nl"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="mt-2 inline-flex items-center text-lg font-semibold text-[#4a7c59] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a7c59]"
                     >
-                      www.goudbebouwd.nl
+                      www.goudgebouwd.nl
                     </a>
                   </div>
                 </div>

--- a/src/components/generated/GoudGebouwdAboutPage.tsx
+++ b/src/components/generated/GoudGebouwdAboutPage.tsx
@@ -256,12 +256,12 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
                       Geïnspireerd door
                     </h3>
                     <a
-                      href="https://www.goudbebouwd.nl"
+                      href="https://www.goudgebouwd.nl"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="mt-2 inline-flex items-center text-lg font-semibold text-[#4a7c59] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a7c59]"
                     >
-                      www.goudbebouwd.nl
+                      www.goudgebouwd.nl
                     </a>
                   </div>
                 </div>

--- a/src/components/generated/coming soon
+++ b/src/components/generated/coming soon
@@ -256,12 +256,12 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
                       Geïnspireerd door
                     </h3>
                     <a
-                      href="https://www.goudbebouwd.nl"
+                      href="https://www.goudgebouwd.nl"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="mt-2 inline-flex items-center text-lg font-semibold text-[#4a7c59] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a7c59]"
                     >
-                      www.goudbebouwd.nl
+                      www.goudgebouwd.nl
                     </a>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- replace the outdated goudbebouwd.nl link with goudgebouwd.nl across the coming soon components

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f53c2936f883258f04a1f82b1f95ed