### PR TITLE
Remove live stories button from coming soon page

### DIFF
--- a/src/CominSoon.tsx
+++ b/src/CominSoon.tsx
@@ -50,13 +50,6 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
                   >
                     Blijf op de hoogte
                   </a>
-                  <button
-                    type="button"
-                    onClick={() => props.onNavigate?.("feed")}
-                    className="inline-flex items-center justify-center rounded-full border border-[#4a7c59] px-6 py-3 text-base font-semibold text-[#4a7c59] transition hover:bg-[#4a7c59]/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a7c59]"
-                  >
-                    Bekijk verhalen die al live zijn
-                  </button>
                 </div>
               </div>
             </motion.section>

--- a/src/components/generated/GoudGebouwdAboutPage.tsx
+++ b/src/components/generated/GoudGebouwdAboutPage.tsx
@@ -50,13 +50,6 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
                   >
                     Blijf op de hoogte
                   </a>
-                  <button
-                    type="button"
-                    onClick={() => props.onNavigate?.("feed")}
-                    className="inline-flex items-center justify-center rounded-full border border-[#4a7c59] px-6 py-3 text-base font-semibold text-[#4a7c59] transition hover:bg-[#4a7c59]/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a7c59]"
-                  >
-                    Bekijk verhalen die al live zijn
-                  </button>
                 </div>
               </div>
             </motion.section>

--- a/src/components/generated/coming soon
+++ b/src/components/generated/coming soon
@@ -50,13 +50,6 @@ export const GoudGebouwdAboutPage = (props: GoudGebouwdAboutPageProps) => {
                   >
                     Blijf op de hoogte
                   </a>
-                  <button
-                    type="button"
-                    onClick={() => props.onNavigate?.("feed")}
-                    className="inline-flex items-center justify-center rounded-full border border-[#4a7c59] px-6 py-3 text-base font-semibold text-[#4a7c59] transition hover:bg-[#4a7c59]/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4a7c59]"
-                  >
-                    Bekijk verhalen die al live zijn
-                  </button>
                 </div>
               </div>
             </motion.section>


### PR DESCRIPTION
## Summary
- remove the "Bekijk verhalen die al live zijn" button from the coming soon page
- update the generated about page variants to match

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68fb46159158832596c86b0a412b3e8b